### PR TITLE
Notifier tests

### DIFF
--- a/dojo_toolkit/notifier.py
+++ b/dojo_toolkit/notifier.py
@@ -10,19 +10,25 @@ class BaseNotifier(object):
         self.fail_img_path = os.path.join(ASSETS_DIR, 'r.jpg')
         self.success_img_path = os.path.join(ASSETS_DIR, 'g.jpg')
 
+    def get_notifier(self):
+        raise NotImplementedError()
+
     def notify(self, message, image=None):
-        raise NotImplemented()
+        raise NotImplementedError()
 
 
 class GnomeNotifier(BaseNotifier):
     def __init__(self):
         super(GnomeNotifier, self).__init__()
 
-        Notify.init('not')
-        self._notifier = Notify.Notification.new('', '', '')
-
         self.fail_img = GdkPixbuf.Pixbuf.new_from_file(self.fail_img_path)
         self.success_img = GdkPixbuf.Pixbuf.new_from_file(self.success_img_path)
+
+        self._notifier = self.get_notifier()
+
+    def get_notifier(self):
+        Notify.init('not')
+        return Notify.Notification.new('', '', '')
 
     def notify(self, message, image_path='', timeout=5 * 60 * 1000):
         self._notifier.update(message, '', image_path)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -vv --cov=dojo_toolkit

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+pytest-cov
+flake8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 pytest
 pytest-cov
-flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-argh==0.26.2
-pathtools==0.1.2
 pgi==0.0.11.1
-PyYAML==3.11
 watchdog==0.8.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from dojo_toolkit.notifier import GnomeNotifier
+
+
+@pytest.fixture
+def gnome_notifier():
+    return GnomeNotifier()

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,57 @@
+from unittest import mock
+from unittest.mock import call
+
+import pytest
+
+from dojo_toolkit.notifier import BaseNotifier, GnomeNotifier
+
+
+def test_base_notifier():
+    notifier = BaseNotifier()
+    assert notifier.fail_img_path
+    assert notifier.success_img_path
+    with pytest.raises(NotImplementedError):
+        notifier.notify('foo')
+    with pytest.raises(NotImplementedError):
+        notifier.get_notifier()
+
+
+@mock.patch('dojo_toolkit.notifier.Notify')
+@mock.patch('dojo_toolkit.notifier.GdkPixbuf')
+def test_gnome_notifier(pixbuf, notify):
+    gnome_notifier = GnomeNotifier()
+
+    calls = [call(gnome_notifier.fail_img_path), call(gnome_notifier.success_img_path)]
+    pixbuf.Pixbuf.new_from_file.assert_has_calls(calls)
+
+
+@mock.patch('dojo_toolkit.notifier.Notify')
+def test_gnome_notifier_get_notifier(notify, gnome_notifier):
+    assert gnome_notifier.get_notifier()
+
+    notify.init.assert_called_once_with('not')
+    notify.Notification.new.assert_called_once_with('', '', '')
+
+
+@mock.patch('dojo_toolkit.notifier.GnomeNotifier.get_notifier')
+def test_gnome_notifier_notify(get_notifier, gnome_notifier):
+    gnome_notifier = GnomeNotifier()
+
+    gnome_notifier.notify('message', 'foo.png', 10)
+
+    _notifier = get_notifier.return_value
+    _notifier.update.assert_called_with('message', '', 'foo.png')
+    _notifier.set_timeout.assert_called_with(10)
+    assert _notifier.show.called
+
+
+@mock.patch('dojo_toolkit.notifier.GnomeNotifier.notify')
+def test_gnome_notifier_success(notify, gnome_notifier):
+    gnome_notifier.success('message')
+    notify.assert_called_with('message', gnome_notifier.success_img_path)
+
+
+@mock.patch('dojo_toolkit.notifier.GnomeNotifier.notify')
+def test_gnome_notifier_fail(notify, gnome_notifier):
+    gnome_notifier.fail('message')
+    notify.assert_called_with('message', gnome_notifier.fail_img_path)


### PR DESCRIPTION
Add notifier tests and set up travis for Continuous Integration (CI): https://travis-ci.org/grupy-sanca/dojo-toolkit/

CI breaks because of pgi/Libnotify :disappointed:  Gonna deactivate github-travis integration.