### PR TITLE
Fix round info

### DIFF
--- a/dojo_toolkit/dojo.py
+++ b/dojo_toolkit/dojo.py
@@ -1,3 +1,4 @@
+import time
 from threading import Thread
 
 from six import moves
@@ -58,9 +59,10 @@ class Dojo:
         print('Round started! {} minutes left...'.format(self.round_time))
 
     def round_info(self):
-        if self.timer.ellapsed_time == 60:
-            self.notifier.notify('60 seconds...')
-            print('Round finished in 60 seconds')
+        if self.timer.ellapsed_time == self.timer.duration - 60:
+            self.notifier.notify('60 seconds to round finish...')
+            print('Round is going to finish in 60 seconds')
+            self.info_notified = True
 
     def round_finished(self):
         self.notifier.notify('Time Up', timeout=15 * 1000)
@@ -74,4 +76,5 @@ class Dojo:
             self.round_start()
             while self.timer.is_running:
                 self.round_info()
+                time.sleep(0.8)
             self.round_finished()

--- a/dojo_toolkit/dojo.py
+++ b/dojo_toolkit/dojo.py
@@ -46,12 +46,16 @@ class Dojo:
         self.is_running = False
 
     def await_pilot_exchange(self):
+        print('Awaiting the pilot and co-pilot to enter their positions.')
+        print('Press <Enter> when they are ready')
         moves.input()
 
     def round_start(self):
         self.timer.start()
         self.sound_player.play_start()
         self.round_started = True
+
+        print('Round started! {} minutes left...'.format(self.round_time))
 
     def round_info(self):
         if self.timer.ellapsed_time == 60:
@@ -62,15 +66,12 @@ class Dojo:
         self.notifier.notify('Time Up', timeout=15 * 1000)
         self.sound_player.play_timeup()
         self.round_started = False
+        print('Round finished!\n')
 
     def dojo(self):
         while self.is_running:
-            print('Awaiting the pilot and co-pilot to enter their positions.')
-            print('Press <Enter> when they are ready')
             self.await_pilot_exchange()
             self.round_start()
-            print('Round started! {} minutes left...'.format(self.round_time))
             while self.timer.is_running:
                 self.round_info()
             self.round_finished()
-            print('Round finished!')

--- a/tests/test_dojo.py
+++ b/tests/test_dojo.py
@@ -71,6 +71,7 @@ def test_dojo_round_info_without_notification(mocked_dojo):
 
 
 def test_dojo_round_info_with_notification(mocked_dojo):
+    mocked_dojo.timer.duration = 120
     mocked_dojo.timer.ellapsed_time = 60
     mocked_dojo.round_info()
     assert mocked_dojo.notifier.notify.called


### PR DESCRIPTION
Round info (60 seconds remaining print/notification) was being show multiple times. Fix this behavior and show it only once.
