### PR TITLE
Refactor code handler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+-   repo: git@github.com:pre-commit/pre-commit-hooks
+    sha: 516cc9fa72ad09699f2c03ffbd0aa7f60d75b59a
+    hooks:
+    - id: debug-statements
+    - id: trailing-whitespace
+    - id: check-merge-conflict
+    - id: flake8
+      args: ['--exclude=docs/*,*migrations*', '--ignore=E501']

--- a/dojo_toolkit/code_handler.py
+++ b/dojo_toolkit/code_handler.py
@@ -11,9 +11,7 @@ class DojoCodeHandler(PatternMatchingEventHandler):
 
     def __init__(self, *args, **kwargs):
         self.dojo = kwargs.pop('dojo')
-        self.notifier = kwargs.pop('notifier')
         self.test_runner = kwargs.pop('test_runner')
-        self.sound_player = kwargs.pop('sound_player')
 
         super(DojoCodeHandler, self).__init__(*args, **kwargs)
 
@@ -21,14 +19,6 @@ class DojoCodeHandler(PatternMatchingEventHandler):
 
     def get_last_test_run_interval(self):
         return time.time() - self.last_test_run_time
-
-    def handle_success(self):
-        self.notifier.success('OK TO TALK')
-        self.sound_player.play_success()
-        print('Tests passed!')
-
-    def handle_fail(self):
-        self.notifier.fail('NOT OK TO TALK')
 
     def handle_stopped_round(self):
         self.notifier.notify('Round has not been started')
@@ -46,10 +36,6 @@ class DojoCodeHandler(PatternMatchingEventHandler):
 
         if self.get_last_test_run_interval() < self.min_test_time_interval:
             return
-
         self.last_test_run_time = time.time()
 
-        if self.test_runner.run():
-            self.handle_success()
-        else:
-            self.handle_fail()
+        self.test_runner.run()

--- a/dojo_toolkit/code_handler.py
+++ b/dojo_toolkit/code_handler.py
@@ -1,5 +1,6 @@
 import time
 
+from dojo_toolkit.notifier import notifier
 from watchdog.events import PatternMatchingEventHandler
 
 
@@ -21,7 +22,7 @@ class DojoCodeHandler(PatternMatchingEventHandler):
         return time.time() - self.last_test_run_time
 
     def handle_stopped_round(self):
-        self.notifier.notify('Round has not been started')
+        notifier.notify('Round has not been started')
         print('Press <Enter> to start the round')
 
     def on_modified(self, event):

--- a/dojo_toolkit/dojo.py
+++ b/dojo_toolkit/dojo.py
@@ -12,7 +12,7 @@ from dojo_toolkit.timer import Timer
 from dojo_toolkit.utils import mock
 
 
-class Dojo:
+class Dojo(object):
     ROUND_TIME = 5
 
     def __init__(self, code_path, round_time=None, mute=False, test_runner=None):

--- a/dojo_toolkit/dojo.py
+++ b/dojo_toolkit/dojo.py
@@ -58,7 +58,7 @@ class Dojo(object):
 
     def round_info(self):
         if self.timer.ellapsed_time == self.timer.duration - 60:
-            self.notifier.notify('60 seconds to round finish...')
+            notifier.notify('60 seconds to round finish...')
             print('Round is going to finish in 60 seconds')
             self.info_notified = True
 

--- a/dojo_toolkit/dojo.py
+++ b/dojo_toolkit/dojo.py
@@ -5,7 +5,7 @@ from six import moves
 from watchdog.observers import Observer
 
 from dojo_toolkit.code_handler import DojoCodeHandler
-from dojo_toolkit.notifier import GnomeNotifier
+from dojo_toolkit.notifier import notifier
 from dojo_toolkit.sound_handler import SoundHandler
 from dojo_toolkit.test_runner import DoctestTestRunner
 from dojo_toolkit.timer import Timer
@@ -15,25 +15,23 @@ from dojo_toolkit.utils import mock
 class Dojo:
     ROUND_TIME = 5
 
-    def __init__(self, code_path, round_time=None, mute=False, notifier=None, test_runner=None):
+    def __init__(self, code_path, round_time=None, mute=False, test_runner=None):
         self.code_path = code_path
         self.round_time = round_time or self.ROUND_TIME
-        self.notifier = notifier or GnomeNotifier()
-        self.test_runner = test_runner or DoctestTestRunner(code_path=code_path)
         self.sound_player = mock.Mock() if mute else SoundHandler()
 
-        self.event_handler = DojoCodeHandler(dojo=self,
-                                             notifier=self.notifier,
-                                             test_runner=self.test_runner,
-                                             sound_player=self.sound_player)
+        test_runner = test_runner or DoctestTestRunner(code_path=code_path,
+                                                       sound_player=self.sound_player)
+        event_handler = DojoCodeHandler(dojo=self, test_runner=test_runner)
+
         self.observer = Observer()
-        self.observer.schedule(self.event_handler, self.code_path, recursive=False)
+        self.observer.schedule(event_handler, self.code_path, recursive=False)
 
         self.timer = Timer(self.round_time)
 
     def start(self):
         self.observer.start()
-        print('\n\n\n\nWatching: {} folder'.format(self.code_path))
+        print('\nWatching: {} folder'.format(self.code_path))
 
         self.is_running = True
         print('Dojo toolkit started!')
@@ -65,7 +63,7 @@ class Dojo:
             self.info_notified = True
 
     def round_finished(self):
-        self.notifier.notify('Time Up', timeout=15 * 1000)
+        notifier.notify('Time Up', timeout=15 * 1000)
         self.sound_player.play_timeup()
         self.round_started = False
         print('Round finished!\n')

--- a/dojo_toolkit/notifier.py
+++ b/dojo_toolkit/notifier.py
@@ -47,3 +47,6 @@ class GnomeNotifier(BaseNotifier):
 
     def fail(self, message):
         self.notify(message, self.fail_img_path)
+
+
+notifier = GnomeNotifier()

--- a/dojo_toolkit/sound_handler.py
+++ b/dojo_toolkit/sound_handler.py
@@ -5,7 +5,7 @@ import pyglet
 from .settings import SOUNDS_DIR
 
 
-class SoundHandler:
+class SoundHandler(object):
     def __init__(self):
         self.player = pyglet.media.Player()
 

--- a/dojo_toolkit/test_runner.py
+++ b/dojo_toolkit/test_runner.py
@@ -14,19 +14,19 @@ class SubprocessTestRunner(object):
     cmd = None
 
     def __init__(self, code_path, sound_player):
-        self._cmd = self.cmd.format(code_path)
+        self.cmd = self.cmd.format(code_path)
         self.sound_player = sound_player
 
     def run(self):
         """
         run a test cmd using subprocess
         """
-        process = Popen([self._cmd], shell=True, stdout=PIPE)
+        process = Popen([self.cmd], shell=True, stdout=PIPE)
         process.wait()
 
         success = process.returncode == 0
         self.handle_result(success)
-        print('\n'.join(process.stdout.readlines()))
+        print('\n'.join(str(line) for line in process.stdout.readlines()))
 
         return success
 

--- a/dojo_toolkit/test_runner.py
+++ b/dojo_toolkit/test_runner.py
@@ -1,32 +1,49 @@
 """
 Module for running tests like doctest and unittest
 """
-from subprocess import Popen
+from subprocess import Popen, PIPE
 
 
-class BaseTestRunner():
-    """
-    Base class to all test runners
-    """
-
-    def __init__(self, code_path):
-        self.code_path = code_path
+from .notifier import notifier
 
 
-class SubprocessTestRunner(BaseTestRunner):
+class SubprocessTestRunner(object):
     """
     Base class to all test runners that use subprocess module.
     """
-    cmd = ""
+    cmd = None
+
+    def __init__(self, code_path, sound_player):
+        self._cmd = self.cmd.format(code_path)
+        self.sound_player = sound_player
 
     def run(self):
         """
         run a test cmd using subprocess
         """
-        cmd = self.cmd.format(self.code_path)
-        process = Popen([cmd], shell=True)
+        process = Popen([self._cmd], shell=True, stdout=PIPE)
         process.wait()
-        return process.returncode == 0
+
+        success = process.returncode == 0
+        self.handle_result(success)
+        print('\n'.join(process.stdout.readlines()))
+
+        return success
+
+    def handle_result(self, success):
+        if success:
+            self.handle_success()
+        else:
+            self.handle_failure()
+
+    def handle_success(self):
+        print('\nTests passed!\n')
+        notifier.success('OK TO TALK')
+        self.sound_player.play_success()
+
+    def handle_failure(self):
+        print('\nTests failed!\n')
+        notifier.fail('NOT OK TO TALK')
 
 
 class DoctestTestRunner(SubprocessTestRunner):

--- a/dojo_toolkit/timer.py
+++ b/dojo_toolkit/timer.py
@@ -3,7 +3,7 @@ from threading import Thread
 import time
 
 
-class Timer:
+class Timer(object):
     """
     A timer that runs on a separated thread and "ticks" every second. It
     keeps track of the ellapsed time.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,5 @@ from dojo_toolkit.utils import mock
 
 @pytest.fixture
 def mocked_code_handler():
-    code_handler = DojoCodeHandler(dojo=mock.Mock(),
-                                   notifier=mock.Mock(),
-                                   test_runner=mock.Mock(),
-                                   sound_player=mock.Mock())
+    code_handler = DojoCodeHandler(test_runner=mock.Mock(), dojo=mock.Mock())
     return code_handler

--- a/tests/test_dojo.py
+++ b/tests/test_dojo.py
@@ -9,7 +9,7 @@ def mocked_dojo():
     with mock.patch('dojo_toolkit.dojo.Observer'), \
             mock.patch('dojo_toolkit.dojo.Timer'), \
             mock.patch('dojo_toolkit.dojo.SoundHandler'):
-        return Dojo('/foo/bar', notifier=mock.Mock(), test_runner=mock.Mock())
+        return Dojo('/foo/bar', test_runner=mock.Mock())
 
 
 @mock.patch('dojo_toolkit.dojo.Thread')
@@ -65,21 +65,24 @@ def test_dojo_round_start(mocked_dojo):
     assert mocked_dojo.sound_player.play_start.called
 
 
-def test_dojo_round_info_without_notification(mocked_dojo):
+@mock.patch('dojo_toolkit.dojo.notifier')
+def test_dojo_round_info_without_notification(notifier, mocked_dojo):
     mocked_dojo.round_info()
-    assert not mocked_dojo.notifier.notify.called
+    assert not notifier.notify.called
 
 
-def test_dojo_round_info_with_notification(mocked_dojo):
+@mock.patch('dojo_toolkit.dojo.notifier')
+def test_dojo_round_info_with_notification(notifier, mocked_dojo):
     mocked_dojo.timer.duration = 120
     mocked_dojo.timer.ellapsed_time = 60
     mocked_dojo.round_info()
-    assert mocked_dojo.notifier.notify.called
+    assert notifier.notify.called
 
 
-def test_dojo_round_finished(mocked_dojo):
+@mock.patch('dojo_toolkit.dojo.notifier')
+def test_dojo_round_finished(notifier, mocked_dojo):
     mocked_dojo.round_finished()
-    assert mocked_dojo.notifier.notify.called
+    assert notifier.notify.called
     assert mocked_dojo.sound_player.play_timeup.called
 
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,4 +1,10 @@
-from tests.conftest import mock
+from dojo_toolkit.code_handler import DojoCodeHandler
+from dojo_toolkit.utils import mock
+
+
+def test_code_handler():
+    code_handler = DojoCodeHandler(test_runner=mock.Mock(), dojo=mock.Mock())
+    assert code_handler.last_test_run_time
 
 
 def test_code_handler_get_last_test_run_interval(mocked_code_handler):
@@ -8,28 +14,8 @@ def test_code_handler_get_last_test_run_interval(mocked_code_handler):
         assert mocked_code_handler.get_last_test_run_interval() == 10
 
 
-def test_code_handler_handle_success(mocked_code_handler):
-    mocked_code_handler.handle_success()
-
-    assert mocked_code_handler.notifier.success.called
-    assert mocked_code_handler.sound_player.play_success.called
-
-
-def test_code_handler_handle_fail(mocked_code_handler):
-    mocked_code_handler.handle_fail()
-
-    assert mocked_code_handler.notifier.fail.called
-
-
-def test_code_handler_handle_stopped_round(mocked_code_handler):
-    mocked_code_handler.handle_stopped_round()
-
-    assert mocked_code_handler.notifier.notify.called
-
-
-@mock.patch('dojo_toolkit.code_handler.DojoCodeHandler.handle_success')
 @mock.patch('dojo_toolkit.code_handler.DojoCodeHandler.get_last_test_run_interval')
-def test_code_handler_on_modified(get_interval, handle_success, mocked_code_handler):
+def test_code_handler_on_modified(get_interval, mocked_code_handler):
     mocked_code_handler.test_runner.run.return_value = True
     get_interval.return_value = 10
 
@@ -37,13 +23,10 @@ def test_code_handler_on_modified(get_interval, handle_success, mocked_code_hand
 
     assert get_interval.called
     assert mocked_code_handler.test_runner.run.called
-    assert handle_success.called
 
 
-@mock.patch('dojo_toolkit.code_handler.DojoCodeHandler.handle_success')
 @mock.patch('dojo_toolkit.code_handler.DojoCodeHandler.get_last_test_run_interval')
-def test_code_handler_on_modified_on_short_interval(get_interval, handle_success,
-                                                    mocked_code_handler):
+def test_code_handler_on_modified_on_short_interval(get_interval, mocked_code_handler):
     mocked_code_handler.test_runner.run.return_value = True
     get_interval.return_value = 1
 
@@ -51,12 +34,10 @@ def test_code_handler_on_modified_on_short_interval(get_interval, handle_success
 
     assert get_interval.called
     assert not mocked_code_handler.test_runner.run.called
-    assert not handle_success.called
 
 
-@mock.patch('dojo_toolkit.code_handler.DojoCodeHandler.handle_fail')
 @mock.patch('dojo_toolkit.code_handler.DojoCodeHandler.get_last_test_run_interval')
-def test_code_handler_on_modified_tests_fail(get_interval, handle_fail, mocked_code_handler):
+def test_code_handler_on_modified_tests_fail(get_interval, mocked_code_handler):
     mocked_code_handler.test_runner.run.return_value = False
     get_interval.return_value = 10
 
@@ -64,4 +45,9 @@ def test_code_handler_on_modified_tests_fail(get_interval, handle_fail, mocked_c
 
     assert get_interval.called
     assert mocked_code_handler.test_runner.run.called
-    assert handle_fail.called
+
+
+@mock.patch('dojo_toolkit.code_handler.notifier')
+def test_code_handler_handle_stopped_round(notifier, mocked_code_handler):
+    mocked_code_handler.handle_stopped_round()
+    assert notifier.notify.called

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -1,18 +1,11 @@
-import pytest
 import os
-from dojo_toolkit.test_runner import BaseTestRunner, SubprocessTestRunner, DoctestTestRunner
+
+import pytest
+
+from dojo_toolkit.test_runner import SubprocessTestRunner, DoctestTestRunner
+from dojo_toolkit.utils import mock
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-@pytest.fixture
-def wrong_cmd():
-    return "parangaricutirimicuaro"
-
-
-@pytest.fixture
-def echo_cmd():
-    return "echo birl"
 
 
 @pytest.fixture
@@ -20,62 +13,40 @@ def code_path():
     return "/path/to/my/code"
 
 
-@pytest.fixture
-def subprocess_test_runner(code_path):
-    return SubprocessTestRunner(code_path)
+class MockTestRunner(SubprocessTestRunner):
+    cmd = "echo '{}'"
 
 
 @pytest.fixture
-def base_test_runner(code_path):
-    return BaseTestRunner(code_path)
+def mock_test_runner(code_path):
+    return MockTestRunner(code_path, sound_player=mock.Mock())
+
+
+class WrongTestRunner(DoctestTestRunner):
+    cmd = "parangaricutirimicuaro '{}'"
 
 
 @pytest.fixture
-def doctest_test_runner():
-    return DoctestTestRunner(os.path.join(MODULE_DIR, "data", "doctest_ok_tests"))
+def wrong_test_runner(code_path):
+    with mock.patch('dojo_toolkit.test_runner.notifier'):
+        return WrongTestRunner(code_path, sound_player=mock.Mock())
 
 
-@pytest.fixture
-def doctest_test_runner_fail():
-    return DoctestTestRunner(os.path.join(MODULE_DIR, "data", "doctest_fail_tests"))
-
-
-def test_base(base_test_runner, code_path):
-    """
-    test BaseTestRunner
-    """
-    assert base_test_runner.code_path == code_path
-
-
-def test_subprocess(subprocess_test_runner, code_path, echo_cmd):
+@mock.patch('dojo_toolkit.test_runner.notifier')
+def test_mock(notifier, mock_test_runner, code_path):
     """
     test SubprocessTestRunner when cmd not fail
     """
-    assert subprocess_test_runner.code_path == code_path
-    subprocess_test_runner.cmd = echo_cmd
-    assert subprocess_test_runner.cmd == echo_cmd
-    assert subprocess_test_runner.run()
+    assert code_path in mock_test_runner.cmd
+    assert 'echo' in mock_test_runner.cmd
+    assert mock_test_runner.run()
 
 
-def test_subprocess_fail(subprocess_test_runner, code_path, wrong_cmd):
+@mock.patch('dojo_toolkit.test_runner.notifier')
+def test_mock_fail(notifier, wrong_test_runner, code_path):
     """
     test SubprocessTestRunner when cmd fail
     """
-    assert subprocess_test_runner.code_path == code_path
-    subprocess_test_runner.cmd = wrong_cmd
-    assert subprocess_test_runner.cmd == wrong_cmd
-    assert not subprocess_test_runner.run()
-
-
-def test_subprocess_doctest_run(doctest_test_runner):
-    """
-    test a good doctest
-    """
-    assert doctest_test_runner.run()
-
-
-def test_subprocess_doctest_run_fail(doctest_test_runner_fail):
-    """
-    test a fail doctest
-    """
-    assert not doctest_test_runner_fail.run()
+    assert code_path in wrong_test_runner.cmd
+    assert 'parangaricutirimicuaro' in wrong_test_runner.cmd
+    assert not wrong_test_runner.run()


### PR DESCRIPTION
- Remove test result handling from CodeHandler, since it should only watch the folder and run tests properly.
- Decouple notifier from most classes, it is now provided as an instance.
- Properly use python-2 style classes for better support
