### PR TITLE
Fix branch name in README for links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 Dojo Toolkit
 ============
 
-.. image:: https://github.com/grupy-sanca/dojo-toolkit/actions/workflows/test_push.yaml/badge.svg?branch=master
-  :target: https://github.com/grupy-sanca/dojo-toolkit/actions/workflows/test_push.yaml?query=branch%3Amaster
+.. image:: https://github.com/grupy-sanca/dojo-toolkit/actions/workflows/test_push.yaml/badge.svg?branch=main
+  :target: https://github.com/grupy-sanca/dojo-toolkit/actions/workflows/test_push.yaml?query=branch%3Amain
 
-.. image:: https://coveralls.io/repos/github/grupy-sanca/dojo-toolkit/badge.svg?branch=master
-  :target: https://coveralls.io/github/grupy-sanca/dojo-toolkit?branch=master
+.. image:: https://coveralls.io/repos/github/grupy-sanca/dojo-toolkit/badge.svg?branch=main
+  :target: https://coveralls.io/github/grupy-sanca/dojo-toolkit?branch=main
 
 
 Toolkit for python coding dojos.
@@ -36,7 +36,7 @@ Running:
   $ dojo /path/to/code/directory/
 
 
-For detailed information about running from source: `CONTRIBUING.rst <https://github.com/grupy-sanca/dojo-toolkit/blob/master/CONTRIBUTING.rst>`_
+For detailed information about running from source: `CONTRIBUING.rst <https://github.com/grupy-sanca/dojo-toolkit/blob/main/CONTRIBUTING.rst>`_
 To see the options available use:
 ::
 
@@ -46,7 +46,7 @@ To see the options available use:
 Contributing
 ------------
 
-Check the `CONTRIBUING.rst <https://github.com/grupy-sanca/dojo-toolkit/blob/master/CONTRIBUTING.rst>`_ file to discover how you can help the development of dojo-toolkit.
+Check the `CONTRIBUING.rst <https://github.com/grupy-sanca/dojo-toolkit/blob/main/CONTRIBUTING.rst>`_ file to discover how you can help the development of dojo-toolkit.
 
 
 Dependencies


### PR DESCRIPTION
It was master, now we need to update all the links to match the new branch name (`main`)