### PR TITLE
Add dojo stats module

### DIFF
--- a/dojo_toolkit/dojo.py
+++ b/dojo_toolkit/dojo.py
@@ -1,4 +1,5 @@
 from threading import Thread
+from datetime import datetime
 from unittest import mock
 
 from watchdog.observers import Observer
@@ -8,6 +9,7 @@ from dojo_toolkit.code_handler import DojoCodeHandler
 from dojo_toolkit.sound_handler import SoundHandler
 from dojo_toolkit.test_runner import get_test_runner
 from dojo_toolkit.timer import Timer
+from dojo_toolkit.dojo_stats import DojoStats, display_stats
 
 
 class Dojo:
@@ -19,6 +21,7 @@ class Dojo:
         self.sound_player = mock.Mock() if mute else SoundHandler()
         self.info_notified = False
         self.timer = Timer(self.round_time)
+        self.stats = DojoStats(datetime.now())
 
         test_runner = get_test_runner(test_runner, runner, self.code_path, self.sound_player)
         self.controller = dojo_thread.DojoController(self.timer, self.sound_player)
@@ -29,14 +32,18 @@ class Dojo:
         self.observer.schedule(event_handler, self.code_path, recursive=False)
 
     def start(self):
-        self.observer.start()
-        print(f"\nWatching: {self.code_path} folder")
+        try:
+            self.observer.start()
+            print(f"\nWatching: {self.code_path} folder")
 
-        self.is_running = True
-        print("Dojo toolkit started!")
-        self.thread = Thread(target=dojo_thread.main, args=(self.controller,))
-        self.thread.daemon = True
-        self.thread.start()
-
-        self.thread.join()
-        self.observer.join()
+            self.is_running = True
+            print("Dojo toolkit started!")
+            self.thread = Thread(target=dojo_thread.main, args=(self.controller,))
+            self.thread.daemon = True
+            self.thread.start()
+            self.thread.join()
+            self.observer.join()
+        except KeyboardInterrupt:
+            display_stats(self.stats)
+        except EOFError:
+            display_stats(self.stats)

--- a/dojo_toolkit/dojo.py
+++ b/dojo_toolkit/dojo.py
@@ -26,8 +26,8 @@ class Dojo:
         test_runner = get_test_runner(test_runner, runner, self.code_path, self.sound_player)
         self.controller = dojo_thread.DojoController(
             self.timer,
-            self.stats,
             self.sound_player,
+            self.stats,
         )
 
         event_handler = DojoCodeHandler(dojo=self.controller, test_runner=test_runner)

--- a/dojo_toolkit/dojo.py
+++ b/dojo_toolkit/dojo.py
@@ -1,15 +1,15 @@
-from threading import Thread
 from datetime import datetime
+from threading import Thread
 from unittest import mock
 
 from watchdog.observers import Observer
 
 from dojo_toolkit import dojo_thread
 from dojo_toolkit.code_handler import DojoCodeHandler
+from dojo_toolkit.dojo_stats import DojoStats, display_stats
 from dojo_toolkit.sound_handler import SoundHandler
 from dojo_toolkit.test_runner import get_test_runner
 from dojo_toolkit.timer import Timer
-from dojo_toolkit.dojo_stats import DojoStats, display_stats
 
 
 class Dojo:
@@ -24,7 +24,11 @@ class Dojo:
         self.stats = DojoStats(datetime.now())
 
         test_runner = get_test_runner(test_runner, runner, self.code_path, self.sound_player)
-        self.controller = dojo_thread.DojoController(self.timer, self.sound_player)
+        self.controller = dojo_thread.DojoController(
+            self.timer,
+            self.stats,
+            self.sound_player,
+        )
 
         event_handler = DojoCodeHandler(dojo=self.controller, test_runner=test_runner)
 

--- a/dojo_toolkit/dojo_stats.py
+++ b/dojo_toolkit/dojo_stats.py
@@ -1,0 +1,15 @@
+"""
+Statistics during Dojo run.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class DojoStats:
+    start_time: datetime
+
+
+def display_stats(stats: DojoStats) -> None:
+    now = datetime.now()
+    print(f"Dojo play took {now - stats.start_time}")

--- a/dojo_toolkit/dojo_stats.py
+++ b/dojo_toolkit/dojo_stats.py
@@ -5,11 +5,13 @@ Statistics during Dojo run.
 from dataclasses import dataclass
 from datetime import datetime
 
+
 @dataclass
 class DojoStats:
     start_time: datetime
+    rounds: int = 0
 
 
 def display_stats(stats: DojoStats) -> None:
     now = datetime.now()
-    print(f"Dojo play took {now - stats.start_time}")
+    print(f"\n{stats.rounds} rounds played and took {now - stats.start_time}")

--- a/dojo_toolkit/dojo_thread.py
+++ b/dojo_toolkit/dojo_thread.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 from clint.textui import colored
 
+from dojo_toolkit.dojo_stats import DojoStats
 from dojo_toolkit.notifier import notifier
 from dojo_toolkit.sound_handler import SoundHandler
 from dojo_toolkit.timer import Timer
@@ -11,6 +12,7 @@ from dojo_toolkit.timer import Timer
 @dataclass
 class DojoController:
     timer: Timer
+    stats: DojoStats
     sound_player: SoundHandler
     is_running: bool = True
     round_started: bool = False
@@ -38,6 +40,7 @@ class DojoController:
         notifier.notify("Time Up", timeout=15 * 1000)
         self.sound_player.play_timeup()
         self.round_started = False
+        self.stats.rounds += 1
         print("Round finished!\n")
 
 

--- a/dojo_toolkit/dojo_thread.py
+++ b/dojo_toolkit/dojo_thread.py
@@ -12,8 +12,8 @@ from dojo_toolkit.timer import Timer
 @dataclass
 class DojoController:
     timer: Timer
-    stats: DojoStats
     sound_player: SoundHandler
+    stats: DojoStats
     is_running: bool = True
     round_started: bool = False
     info_notified: bool = False

--- a/tests/test_dojo_thread.py
+++ b/tests/test_dojo_thread.py
@@ -9,8 +9,9 @@ from dojo_toolkit.dojo_thread import DojoController, main
 def dojo_controller():
     timer_mock = mock.Mock()
     sound_handler_mock = mock.Mock()
+    stats_mock = mock.Mock(rounds=0)
     timer_mock.duration = 10
-    return DojoController(timer_mock, sound_handler_mock)
+    return DojoController(timer_mock, sound_handler_mock, stats_mock)
 
 
 @mock.patch("dojo_toolkit.dojo_thread.DojoController.await_pilot_exchange")


### PR DESCRIPTION
Right now the program handles ctrl+c and ctrl+d exit, displaying to the user how much time iterated and for how long. To capture ctrl+z we would need to implement a global state of the app and capture the OS signal it, to then print the stats.

This is a first of many PRs. I think the dojo should have a global state to hold the information for the current stats and some more like the pilot changes and test passed. With this state been available we can observe its changes and implement code snapshot as mentioned in #90 